### PR TITLE
Support toot(post) with multibyte languages.

### DIFF
--- a/mastodon-lite.js
+++ b/mastodon-lite.js
@@ -60,7 +60,7 @@ Mastodon.prototype.post = function (message, callback) {
   config.path = self.config.api + '/statuses';
   config.headers = {
     'Authorization': 'Bearer ' + self.config.access_token,
-    'Content-Length': message.length
+    'Content-Length': Buffer.byteLength(message)
   };
 
   if (!callback) {


### PR DESCRIPTION
Currently, this software could not toot(post) text with multibyte languages properly (e.g. Japanese).
For example, posting "サンドイッチ" becomes "サン". Text is broken.

This PR fix that issue.